### PR TITLE
Fix bug with byte[] / base64 handling and array handling in general

### DIFF
--- a/RestSharp.Rpc.Tests.Unit/Extensions/XmlRpcRestRequestExtensions.cs
+++ b/RestSharp.Rpc.Tests.Unit/Extensions/XmlRpcRestRequestExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Linq;
+
+namespace RestSharp.Rpc.Tests.Unit.Extensions
+{
+    public static class XmlRpcRestRequestExtensions
+    {
+        public static string RequestBody(this XmlRpcRestRequest request)
+        {
+            var requestBody = request
+                .Parameters
+                .SingleOrDefault(x => x.Type == ParameterType.RequestBody)
+               ?.Value
+               ?.ToString();
+            return requestBody;
+        }
+    }
+}

--- a/RestSharp.Rpc.Tests.Unit/Properties/AssemblyInfo.cs
+++ b/RestSharp.Rpc.Tests.Unit/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RestSharp.Rpc.Tests.Unit")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RestSharp.Rpc.Tests.Unit")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f1255ed7-7332-4814-af2d-c45e6394af68")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RestSharp.Rpc.Tests.Unit/RestSharp.Rpc.Tests.Unit.csproj
+++ b/RestSharp.Rpc.Tests.Unit/RestSharp.Rpc.Tests.Unit.csproj
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F1255ED7-7332-4814-AF2D-C45E6394AF68}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RestSharp.Rpc.Tests.Unit</RootNamespace>
+    <AssemblyName>RestSharp.Rpc.Tests.Unit</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="RestSharp, Version=105.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.0.0\lib\net4\RestSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Extensions\XmlRpcRestRequestExtensions.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerialisationTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RestSharp.Rpc\RestSharp.Rpc.csproj">
+      <Project>{1F6AA62F-D8FB-4D80-B1F3-D295CF6C8165}</Project>
+      <Name>RestSharp.Rpc</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RestSharp.Rpc.Tests.Unit/SerialisationTests.cs
+++ b/RestSharp.Rpc.Tests.Unit/SerialisationTests.cs
@@ -1,0 +1,112 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.XPath;
+using NUnit.Framework;
+using RestSharp.Rpc.Tests.Unit.Extensions;
+
+namespace RestSharp.Rpc.Tests.Unit
+{
+    public class SerialisationTests
+    {
+        [Test]
+        public void Base64Test()
+        {
+            const string fileContent = "some file content goes here";
+            var data = Encoding.ASCII.GetBytes(fileContent);
+
+            var request = new XmlRpcRestRequest("some.method");
+            request.AddXmlRpcBody(
+                "",
+                data);
+
+            Assert
+                .That(request
+                    .Parameters[1]
+                    .Value
+                    .ToString()
+                    .Contains("<base64>"));
+
+            var requestBody = request.RequestBody();
+
+            Assert.That(
+                requestBody,
+                Is.Not.Null,
+                "The request body parameter could not be found");
+
+            if (requestBody == null) return;
+
+            using (var sr = new StringReader(requestBody))
+            {
+                var doc = new XPathDocument(sr);
+                var nav = doc.CreateNavigator();
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param").Count,
+                    Is.EqualTo(2),
+                    "There should be 2 parameters");
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param/value/string").Count,
+                    Is.EqualTo(1),
+                    "There should be 1 string parameter");
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param/value/base64").Count,
+                    Is.EqualTo(1),
+                    "There should be 1 base64 parameter");
+            }
+        }
+
+        [Test]
+        public void ListTest()
+        {
+            var data = new[]
+            {
+                "one",
+                "two",
+                "three"
+            };
+
+            var request = new XmlRpcRestRequest("some.method");
+            request.AddXmlRpcBody(
+                "",
+                data);
+
+            var requestBody = request.RequestBody();
+
+            Assert.That(
+                requestBody,
+                Is.Not.Null,
+                "The request body parameter could not be found");
+
+            if (requestBody == null) return;
+
+            using (var sr = new StringReader(requestBody))
+            {
+                var doc = new XPathDocument(sr);
+                var nav = doc.CreateNavigator();
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param").Count,
+                    Is.EqualTo(2),
+                    "There should be 2 parameters");
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param/value/string").Count,
+                    Is.EqualTo(1),
+                    "There should be 1 string parameter");
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param/value/array").Count,
+                    Is.EqualTo(1),
+                    "There should be 1 array parameter");
+
+                Assert.That(
+                    nav.Select("//methodCall/params/param/value/array/data/value/string").Count,
+                    Is.EqualTo(3),
+                    "The array should have 3 (string) elements");
+            }
+        }
+    }
+}

--- a/RestSharp.Rpc.Tests.Unit/packages.config
+++ b/RestSharp.Rpc.Tests.Unit/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.0" targetFramework="net452" />
+  <package id="RestSharp" version="105.0.0" targetFramework="net452" />
+</packages>

--- a/RestSharp.Rpc.sln
+++ b/RestSharp.Rpc.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSharp.Rpc", "RestSharp.Rpc\RestSharp.Rpc.csproj", "{1F6AA62F-D8FB-4D80-B1F3-D295CF6C8165}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSharp.Rpc.Tests.Unit", "RestSharp.Rpc.Tests.Unit\RestSharp.Rpc.Tests.Unit.csproj", "{F1255ED7-7332-4814-AF2D-C45E6394AF68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{1F6AA62F-D8FB-4D80-B1F3-D295CF6C8165}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1F6AA62F-D8FB-4D80-B1F3-D295CF6C8165}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1F6AA62F-D8FB-4D80-B1F3-D295CF6C8165}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F1255ED7-7332-4814-AF2D-C45E6394AF68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F1255ED7-7332-4814-AF2D-C45E6394AF68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F1255ED7-7332-4814-AF2D-C45E6394AF68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F1255ED7-7332-4814-AF2D-C45E6394AF68}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RestSharp.Rpc/Attributes/ByOrdinalAttribute.cs
+++ b/RestSharp.Rpc/Attributes/ByOrdinalAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace RestSharp.Rpc.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property)]
+    public class ByOrdinalAttribute : Attribute
+    {
+        public int Order { get; set; }
+    }
+}

--- a/RestSharp.Rpc/Extensions/EnumerableExtensions.cs
+++ b/RestSharp.Rpc/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RestSharp.Rpc.Extensions
+{
+    public static class EnumerableExtensions
+    {
+        public static void Each<T>(this IEnumerable<T> ie, Action<T, int> action)
+        {
+            var i = 0;
+            foreach (var e in ie) action(e, i++);
+        }
+    }
+}

--- a/RestSharp.Rpc/RestSharp.Rpc.csproj
+++ b/RestSharp.Rpc/RestSharp.Rpc.csproj
@@ -44,7 +44,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ByOrdinalAttribute.cs" />
     <Compile Include="Deserializers\XmlRpcDeserializer.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="XmlRpcFaultException.cs" />
     <Compile Include="XmlRpcRestClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -54,6 +56,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="RestSharp.Rpc.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/RestSharp.Rpc/Serializers/XmlRpcSerializer.cs
+++ b/RestSharp.Rpc/Serializers/XmlRpcSerializer.cs
@@ -61,8 +61,12 @@ namespace RestSharp.Serializers {
 #endif
                 {
                SerializeScaler( paramsElement, param );
-            } else if ( propType is IList ) {
-               SerializeArray( paramsElement, ( IList ) param );
+            } else if ( propType == typeof( byte[] ) ) {
+               paramsElement.Add( new XElement("param", SerializeValue( param ) ) );
+            } else if ( propType.IsArray ) {
+               var valueElement = new XElement( "value" );
+               SerializeArray( valueElement, ( IList ) param );
+               paramsElement.Add( new XElement( "param", valueElement ) );
             } else {
                SerializeStruct( paramsElement, param );
             }


### PR DESCRIPTION
Thanks for creating this, I've found it very useful so far. However, I found an issue when handling byte[], the parameter for the RequestBody would get serialised as an empty `<struct />` tag. I've fixed this issue and also another issue around array handling in general.

There is also a unit test project to highlight the issues.

I created a myget account and uploaded a test [package](https://www.myget.org/feed/antonyscott/package/nuget/RestSharp.Rpc.antony-scott) there so I could test it in my spike application.
